### PR TITLE
bugfix. disable connection type ( HTTP1 )

### DIFF
--- a/pkg/argowf/client.go
+++ b/pkg/argowf/client.go
@@ -36,7 +36,7 @@ func New(host string, port int) (Client, error) {
 			URL:                baseUrl,
 			Secure:             false,
 			InsecureSkipVerify: false,
-			HTTP1:              true,
+			HTTP1:              false,
 		},
 		AuthSupplier: func() string {
 			return ""


### PR DESCRIPTION
tks-batch 가 오랜(?) 시간이 지나면 connection error 가 발생하는 현상을 수정합니다.

grpc 를 HTTP 처럼 인식하게 해주는 option 을 enable 로 설정하였었는데, 이 부분에서 connection 을 무한으로 생성하고 있었습니다.
이게 argowf 버그인건지... 그건 잘 모르겠네요. 
테스트 결과 이 옵션 유무로 connection 을 무한으로 생성하는 현상을 확인하였습니다.

( 참고 : 당시 해당 옵션을 설정한 이유 : LB 에서 grpc 를 지원하지 않는 경우를 위해 true 로 설정했었음  )
